### PR TITLE
Update dependencies and fix lint warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ codecov = {repository = "sile/thrift_codec"}
 
 [dependencies]
 byteorder = "1"
-trackable = "0.2"
+trackable = "1.2"
 serde = { version = "1", optional = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 clap = "2"
-serdeconv = "0.3"
+serdeconv = "0.4"
 
 [[example]]
 name = "decode_message"

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,8 +4,8 @@ use trackable::error::{ErrorKind as TrackableErrorKind, ErrorKindExt};
 
 /// This crate specific error type.
 #[derive(Debug, Clone)]
+#[derive(TrackableError)]
 pub struct Error(TrackableError<ErrorKind>);
-derive_traits_for_trackable_error_newtype!(Error, ErrorKind);
 impl From<std::io::Error> for Error {
     fn from(f: std::io::Error) -> Self {
         ErrorKind::Other.cause(f).into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ mod test {
     use super::*;
 
     #[test]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn it_works() {
         let message = Message::oneway("foo_method", 1, Struct::from(("arg1", 2)));
         let mut buf = Vec::new();


### PR DESCRIPTION
Hi! Thanks for merging [my earlier PR](https://github.com/sile/rustracing/pull/12). I'm still working through my dependency tree, filing PRs to crates that could use some updates to their dependencies. There might be a few more PRs coming depending on how things shape out. 

I left Clap at 2.0 as it can be a really big dependency, and if you've got a lot of crates using it, then mixing clap 2 and clap 3 might be annoying.

As always, if it's convenient, could you please cut a release after merging, so I can update my projects and move on to the next source of duplicated crates 🕵️