### PR TITLE
Remove macro_use of serde

### DIFF
--- a/src/data/data_inner.rs
+++ b/src/data/data_inner.rs
@@ -2,7 +2,7 @@ use crate::data::{List, Map, Set, Struct, Uuid};
 
 /// Data.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[allow(missing_docs)]
 pub enum Data {
     Bool(bool),
@@ -133,7 +133,7 @@ impl From<Uuid> for Data {
 
 /// The reference to a `Data`.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[allow(missing_docs)]
 pub enum DataRef<'a> {
     Bool(&'a bool),
@@ -189,7 +189,7 @@ impl<'a> DataRef<'a> {
 
 /// Available data kinds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[allow(missing_docs)]
 pub enum DataKind {
     Bool = 2,

--- a/src/data/element.rs
+++ b/src/data/element.rs
@@ -2,7 +2,7 @@ use crate::data::{DataKind, DataRef, List, Map, Set, Struct, Uuid};
 
 /// A sequence of the values of a data kind.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[allow(missing_docs)]
 pub enum Elements {
     Bool(Vec<bool>),

--- a/src/data/list.rs
+++ b/src/data/list.rs
@@ -5,7 +5,7 @@ use super::Uuid;
 
 /// List.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct List {
     elements: Elements,
 }

--- a/src/data/map.rs
+++ b/src/data/map.rs
@@ -6,7 +6,7 @@ use crate::{ErrorKind, Result};
 /// Internally this is represented by the data structure called "associative array".
 /// No duplicate keys are removed.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Map(Option<Inner>);
 impl Map {
     /// Makes an empty `Map` instance.
@@ -81,7 +81,7 @@ impl Map {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 struct Inner {
     keys: Elements,
     values: Elements,

--- a/src/data/set.rs
+++ b/src/data/set.rs
@@ -8,7 +8,7 @@ use super::Uuid;
 /// Note that internally this has the same representation with `List`.
 /// No duplicate elements are removed.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Set {
     elements: Elements,
 }

--- a/src/data/thrift_struct.rs
+++ b/src/data/thrift_struct.rs
@@ -12,7 +12,7 @@ use crate::data::Data;
 /// assert_eq!(a, b);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Struct {
     fields: Vec<Field>,
 }
@@ -95,7 +95,7 @@ where
 
 /// A struct field.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Field {
     id: i16,
     data: Data,

--- a/src/data/uuid.rs
+++ b/src/data/uuid.rs
@@ -1,6 +1,6 @@
 /// Uuid.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Uuid([u8; 16]);
 
 impl Uuid {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! This crate provides functionalities for encoding/deconding [Thrift][thrift] protocol.
+//! This crate provides functionalities for encoding/decoding [Thrift][thrift] protocol.
 //!
 //! # References
 //!
@@ -50,9 +50,6 @@
 #![warn(missing_docs)]
 #[macro_use]
 extern crate trackable;
-#[cfg(feature = "serde")]
-#[macro_use]
-extern crate serde;
 
 macro_rules! track_io {
     ($expr:expr) => {

--- a/src/message.rs
+++ b/src/message.rs
@@ -3,7 +3,7 @@ use crate::data::Struct;
 
 /// RPC message.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Message {
     method_name: String,
     kind: MessageKind,
@@ -64,7 +64,7 @@ impl Message {
 
 /// The kind of a message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[allow(missing_docs)]
 pub enum MessageKind {
     Call = 1,


### PR DESCRIPTION
I find `#[macro_use] extern crate serde;` obscures the use of a dependency, and removing it modernises the code.
No worries if you disagree.